### PR TITLE
props doc: switch 'settings' and 'properties'

### DIFF
--- a/ast/src/types/props.rs
+++ b/ast/src/types/props.rs
@@ -14,7 +14,7 @@ use super::text::Text;
 
 /// A set of Prosidy properties.
 ///
-/// `PropSet`s consist of both valued _properties_ (e.g. `foo = 'bar'`) and boolean _settings_
+/// `PropSet`s consist of both valued _settings_ (e.g. `foo = 'bar'`) and boolean _properties_
 /// (e.g.  `'baz'`).
 #[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PropSet<'a> {


### PR DESCRIPTION
Assuming I understand this right? It looks like the `settings` field in `PropSet` is the one that's a `HashMap` and so it would be the one that corresponds to key/value mappings like "foo = bar"?