### PR TITLE
Improve parsing of certain items

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-cli"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-parse"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/parse/src/document.pest
+++ b/parse/src/document.pest
@@ -50,18 +50,19 @@ Block = _{
 
 BlockTag = ${
       Key
-    ~ ("[" ~ Props ~ "]")?
+    ~ ("[" ~ Props? ~ "]")?
     ~ ( (":" ~ TrailingWS ~ Block* ~ "#:")
-      | ("{" ~ Paragraph ~ "}")
+      | ("{" ~ Paragraph? ~ "}")
       )?
 }
 
 LiteralTag = ${
       Key
-    ~ ("[" ~ Props ~ "]")?
+    ~ ("[" ~ Props? ~ "]")?
     ~ PUSH(":" ~ (!WHITE_SPACE ~ ANY)*)
     ~ NEWLINE
     ~ Literal
+    ~ WHITE_SPACE*
     ~ LiteralEnd
 }
 
@@ -89,8 +90,8 @@ InlineTag = ${
     !("#" ~ (":" | "+" | "-" | "#"))
     ~ "#"
     ~ Key
-    ~ ("[" ~ Props ~ "]")?
-    ~ ("{" ~ Paragraph ~ "}")?
+    ~ ("[" ~ Props? ~ "]")?
+    ~ ("{" ~ Paragraph? ~ "}")?
 }
 
 SoftBreak = @{ NEWLINE ~ (!NEWLINE ~ WHITE_SPACE)* }
@@ -116,6 +117,7 @@ QuotedText = {
 PlainQuotedText = @{
     (!(PEEK | "\\") ~ ANY)+
 }
+
 
 EscapedQuotedText = @{
     "\\" ~ (PEEK | "\\")

--- a/parse/tests/test03.pro
+++ b/parse/tests/test03.pro
@@ -24,12 +24,18 @@
 #:
 
 #+lit:end
-    #this{isn't} valid at all!
-    #:
-    #:
-    #:
+#this{isn't} valid at all!
+#:
+#:
+#:
 #:end
 
-#+lit[withprops='true', flag]:
+#+lit[flag, withprops='true']:
     this literal has properties!
+#:
+
+#-content:
+    #+lit:
+        Literals can be nested!
+    #:
 #:

--- a/parse/tests/test03.rs
+++ b/parse/tests/test03.rs
@@ -72,7 +72,7 @@ fn expected() -> Document<'static> {
                 props!(),
                 vec![
                     Block::Literal(Literal::from(Text::from(
-                        "    #this{isn\'t} valid at all!\n    #:\n    #:\n    #:\n"
+                        "#this{isn\'t} valid at all!\n#:\n#:\n#:\n"
                     ))),
                 ]
             )
@@ -81,9 +81,24 @@ fn expected() -> Document<'static> {
                 "lit",
                 props!(flag, withprops="true"),
                 vec![
-                    Block::Literal(Literal::from(Text::from(
+                    Literal::from(Text::from(
                         "    this literal has properties!\n"
-                    ))),
+                    )).into(),
+                ]
+            ).into(),
+            Tag::new(
+                "content",
+                props!(),
+                vec![
+                    Tag::new(
+                        "lit",
+                        props!(),
+                        vec![
+                            Literal::from(Text::from(
+                                "        Literals can be nested!\n",
+                            )).into()
+                        ],
+                    ).into(),
                 ]
             ).into(),
         ],

--- a/parse/tests/test04.pro
+++ b/parse/tests/test04.pro
@@ -1,0 +1,26 @@
+## This Source Code Form is subject to the terms of the Mozilla Public
+## License, v. 2.0. If a copy of the MPL was not distributed with this
+## file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+004 - Empty forms
+---
+
+#-block
+
+#-block[]
+
+#-block{}
+
+#-block[]{}
+
+
+#inline
+#inline[]
+#inline{}
+#inline[]{}
+
+#+lit:
+#:
+
+#+lit[]:
+#:

--- a/parse/tests/test04.rs
+++ b/parse/tests/test04.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use pretty_assertions::assert_eq;
+use prosidy_ast::*;
+use prosidy_parse::{parse_document, Result};
+
+const SOURCE: &str = include_str!("test04.pro");
+
+#[test]
+fn test_empty_forms() -> Result<()> {
+    let actual = parse_document(SOURCE)?;
+    assert_eq!(actual, expected());
+    Ok(())
+}
+
+fn expected() -> Document<'static> {
+    Document::new(
+        Meta::new("004 - Empty forms", props! {}),
+        vec![
+            empty_block(),
+            empty_block(),
+            empty_block(),
+            empty_block(),
+            Block::Content(vec![
+                empty_inline(),
+                Inline::SoftBreak,
+                empty_inline(),
+                Inline::SoftBreak,
+                empty_inline(),
+                Inline::SoftBreak,
+                empty_inline(),
+            ]),
+            empty_lit(),
+            empty_lit(),
+        ],
+    )
+}
+
+fn empty_block() -> Block<'static> {
+    BlockTag::new("block", props!(), vec![])
+        .into()
+}
+
+fn empty_inline() -> Inline<'static> {
+    InlineTag::new("inline", props!(), vec![])
+        .into()
+}
+
+fn empty_lit() -> Block<'static> {
+    BlockTag::new("lit", props!(), vec![
+        Block::Literal(Literal::default()),
+    ]).into()
+}

--- a/prosidy/Cargo.toml
+++ b/prosidy/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
- Modifies the parser so that `#foo[]{}` is equivalent to just `#foo`. This allows empty tags to be placed directly next to text, e.g. `#tag{}no-spaces`.
- Modifies the parser so that literal closes can have whitespace before them.