### PR TITLE
Support for named block delimiters

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-cli"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-parse"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/parse/src/document.pest
+++ b/parse/src/document.pest
@@ -43,7 +43,11 @@ Block = _{
 BlockTag = ${
       Key
     ~ ("[" ~ Props? ~ "]")?
-    ~ ( (":" ~ TrailingWS ~ Block* ~ "#:")
+    ~ ( (PUSH(":" ~ (!WHITE_SPACE ~ ANY)*)
+         ~ TrailingWS
+         ~ Block*
+         ~ "#"
+         ~ POP)
       | ("{" ~ Paragraph? ~ "}")
       )?
 }

--- a/parse/tests/test03.pro
+++ b/parse/tests/test03.pro
@@ -24,6 +24,10 @@ title: Tags
     #:
 #:
 
+#-named-end:end-block
+    This block has a named start/end delimiter.
+#:end-block
+
 #+lit:end
 #this{isn't} valid at all!
 #:

--- a/parse/tests/test03.rs
+++ b/parse/tests/test03.rs
@@ -69,6 +69,15 @@ fn expected() -> Document<'static> {
                 .into()],
             )
             .into(),
+            BlockTag::new(
+                "named-end",
+                props!(),
+                vec![
+                    Block::Content(vec![
+                        Text::new("This block has a named start/end delimiter.").into(),
+                    ]),
+                ],
+            ).into(),
             Tag::new(
                 "lit",
                 props!(),

--- a/prosidy/Cargo.toml
+++ b/prosidy/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
Currently, Prosidy allows literal tags to have a name after the opening `:` which must be matched on close, making escaping literal sequences easy (and avoiding problems that languages like XML suffer from, where writing the literal escape sequence inside a literal escape causes all sorts of problems).

@chris-martin pointed out that it can be helpful to use the same syntax on blocks. This is a 100% backward-compatible change and it makes perfect sense! I can see it making partial parses much easier as well.

The following is now valid Prosidy:

```prosidy
#-block-tag:
  This is an untagged block, available in previous versions.
#: 
#-block-tag:endblock
  This block requires "endblock" in the closing tag to close properly.
  This can make orienting yourself in an especially large file much easier.
#:endblock
```