### PR TITLE
Set the literal sigil to #=

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-cli"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/manual/intro.pro
+++ b/manual/intro.pro
@@ -21,7 +21,7 @@ and lets you add as much or as little metadata as you'd like.
 
 This introduction, in #prosidy, looks like this:
 
-#-example[syntax='prosidy']:
+#=example[syntax='prosidy']:
 An introduction to Prosidy
 author: James Alexander Feldman-Crough
 lang: en

--- a/manual/intro.pro
+++ b/manual/intro.pro
@@ -21,7 +21,7 @@ and lets you add as much or as little metadata as you'd like.
 
 This introduction, in #prosidy, looks like this:
 
-#+example[syntax='prosidy']:
+#-example[syntax='prosidy']:
 An introduction to Prosidy
 author: James Alexander Feldman-Crough
 lang: en

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy-parse"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/parse/src/document.pest
+++ b/parse/src/document.pest
@@ -36,7 +36,7 @@ DocumentPropValue = { HeaderText }
 //
 
 Block = _{
-      (("#-" ~ BlockTag) | ("#+" ~ LiteralTag) | (!"#:" ~ Paragraph))
+      (("#-" ~ BlockTag) | ("#=" ~ LiteralTag) | (!"#:" ~ Paragraph))
     ~ TrailingWS
 }
 
@@ -161,10 +161,13 @@ KeyReserved = _ {
     | "\"" | ","
 }
 
+// FIXME: I haven't fully decided if I should even restrict this. XML requires
+// tags to start with underscore or a word char, but as much as XML inspired
+// Prosidy's AST I'm not sure some of it's arbitrary syntax rules are a good
+// fit.
 KeyInitReserved = _ {
     KeyReserved
     | '1' .. '9'
-    | "+"
     | "-"
 }
 

--- a/parse/tests/test03.pro
+++ b/parse/tests/test03.pro
@@ -28,19 +28,19 @@ title: Tags
     This block has a named start/end delimiter.
 #:end-block
 
-#+lit:end
+#=lit:end
 #this{isn't} valid at all!
 #:
 #:
 #:
 #:end
 
-#+lit[flag, withprops='true']:
+#=lit[flag, withprops='true']:
     this literal has properties!
 #:
 
 #-content:
-    #+lit:
+    #=lit:
         Literals can be nested!
     #:
 #:

--- a/parse/tests/test03.rs
+++ b/parse/tests/test03.rs
@@ -10,7 +10,7 @@ use prosidy_parse::{parse_document, Result};
 const SOURCE: &str = include_str!("test03.pro");
 
 #[test]
-fn test_escape() -> Result<()> {
+fn test_tags() -> Result<()> {
     let actual = parse_document(SOURCE)?;
     assert_eq!(actual, expected());
     Ok(())

--- a/parse/tests/test04.pro
+++ b/parse/tests/test04.pro
@@ -19,8 +19,8 @@ title: Empty forms
 #inline{}
 #inline[]{}
 
-#+lit:
+#=lit:
 #:
 
-#+lit[]:
+#=lit[]:
 #:

--- a/prosidy/Cargo.toml
+++ b/prosidy/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "prosidy"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Alex Feldman-Crough <alex@fldcr.com>"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
This allows a mnemonic for literal syntax: the body of a literal is
interpreted exactly as it's written, i.e. the AST will be exactly equal
to the text.

```
#+foo:
#: 
```

should now be written as

```
#=foo
#:
```